### PR TITLE
docs: sync labels across projects

### DIFF
--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -1,0 +1,9 @@
+on: [issues, pull_request]
+jobs:
+  sync-labels:
+    runs-on: ubuntu-latest
+    name: Sync repository labels
+    steps:
+      - uses: cds-snc/covid-alert-server-labels@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Use the cds-snc/covid-alert-server-labels action to keep the labels in sync across all covid alert server projects.